### PR TITLE
PHPCS 4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
+/.cache export-ignore
 /.github export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
 /tests export-ignore
 /phpunit.xml.dist export-ignore
+/psalm.xml export-ignore
+/psalm-baseline.xml export-ignore
+/renovate.json export-ignore

--- a/.github/workflows/format_php.yml
+++ b/.github/workflows/format_php.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
           tools: cs2pr
       - name: Get Composer cache directory

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - name: Get Composer cache directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
         php-version:
           - "8.3"
           - "8.4"
-          - "8.5"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
-          - "8.2"
           - "8.3"
+          - "8.4"
+          - "8.5"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - name: Get Composer cache directory

--- a/IxDFCodingStandard/Helpers/ClassHelper.php
+++ b/IxDFCodingStandard/Helpers/ClassHelper.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Helpers;
+
+/** Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API */
+final class ClassHelper extends \SlevomatCodingStandard\Helpers\ClassHelper
+{
+}

--- a/IxDFCodingStandard/Helpers/TokenHelper.php
+++ b/IxDFCodingStandard/Helpers/TokenHelper.php
@@ -5,4 +5,5 @@ namespace IxDFCodingStandard\Helpers;
 /** Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API */
 final class TokenHelper extends \SlevomatCodingStandard\Helpers\TokenHelper
 {
+    public const array NAME_TOKEN_CODES = parent::NAME_TOKEN_CODES;
 }

--- a/IxDFCodingStandard/Helpers/TokenHelper.php
+++ b/IxDFCodingStandard/Helpers/TokenHelper.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Helpers;
+
+/** Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API */
+final class TokenHelper extends \SlevomatCodingStandard\Helpers\TokenHelper
+{
+}

--- a/IxDFCodingStandard/Sniffs/Classes/ForbidMethodDeclarationSniff.php
+++ b/IxDFCodingStandard/Sniffs/Classes/ForbidMethodDeclarationSniff.php
@@ -2,9 +2,9 @@
 
 namespace IxDFCodingStandard\Sniffs\Classes;
 
+use IxDFCodingStandard\Helpers\ClassHelper;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use SlevomatCodingStandard\Helpers\ClassHelper;
 
 final class ForbidMethodDeclarationSniff implements Sniff
 {

--- a/IxDFCodingStandard/Sniffs/Functions/MissingOptionalArgumentSniff.php
+++ b/IxDFCodingStandard/Sniffs/Functions/MissingOptionalArgumentSniff.php
@@ -2,10 +2,10 @@
 
 namespace IxDFCodingStandard\Sniffs\Functions;
 
+use IxDFCodingStandard\Helpers\TokenHelper;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
-use SlevomatCodingStandard\Helpers\TokenHelper;
 
 /** Inspired by {@see \SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff}. */
 final class MissingOptionalArgumentSniff implements Sniff
@@ -21,7 +21,7 @@ final class MissingOptionalArgumentSniff implements Sniff
     /** @return array<int, (int|string)> */
     public function register(): array
     {
-        return TokenHelper::ONLY_NAME_TOKEN_CODES;
+        return TokenHelper::NAME_TOKEN_CODES;
     }
 
     /** @inheritDoc */

--- a/IxDFCodingStandard/Sniffs/Laravel/BladeTemplateExtractor.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/BladeTemplateExtractor.php
@@ -4,6 +4,7 @@ namespace IxDFCodingStandard\Sniffs\Laravel;
 
 use BadMethodCallException;
 
+/** phpcs:disable IxDFCodingStandard.Laravel.NonExistingBladeTemplate.TemplateNotFound */
 final class BladeTemplateExtractor
 {
     private const INVALID_METHOD_CALL = 'Invalid method call';
@@ -53,7 +54,7 @@ final class BladeTemplateExtractor
             throw new BadMethodCallException(self::INVALID_METHOD_CALL);
         }
 
-        return (string) $matches[2];
+        return $matches[2];
     }
 
     public function getConditionalBladeTemplateName(string $tokenContent): string
@@ -69,7 +70,7 @@ final class BladeTemplateExtractor
             throw new BadMethodCallException(self::INVALID_METHOD_CALL);
         }
 
-        return (string) $matches[2];
+        return $matches[2];
     }
 
     public function getEachBladeTemplateName(string $tokenContent): string
@@ -85,7 +86,7 @@ final class BladeTemplateExtractor
             throw new BadMethodCallException(self::INVALID_METHOD_CALL);
         }
 
-        return (string) $matches[1];
+        return $matches[1];
     }
 
     public function getFirstBladeTemplateName(string $tokenContent): string
@@ -101,6 +102,6 @@ final class BladeTemplateExtractor
             throw new BadMethodCallException(self::INVALID_METHOD_CALL);
         }
 
-        return (string) $matches[2];
+        return $matches[2];
     }
 }

--- a/IxDFCodingStandard/Sniffs/Laravel/DisallowGuardedAttributeSniff.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/DisallowGuardedAttributeSniff.php
@@ -2,9 +2,9 @@
 
 namespace IxDFCodingStandard\Sniffs\Laravel;
 
+use IxDFCodingStandard\Helpers\ClassHelper;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
-use SlevomatCodingStandard\Helpers\ClassHelper;
 
 final class DisallowGuardedAttributeSniff extends AbstractScopeSniff
 {

--- a/IxDFCodingStandard/Sniffs/Laravel/NonExistingBladeTemplateSniff.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/NonExistingBladeTemplateSniff.php
@@ -46,7 +46,7 @@ final class NonExistingBladeTemplateSniff implements Sniff
     }
 
     /** @inheritDoc */
-    public function process(File $phpcsFile, $stackPtr): int // phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded, SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
+    public function process(File $phpcsFile, $stackPtr): int // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
     {
         $filename = $phpcsFile->getFilename();
 

--- a/IxDFCodingStandard/Sniffs/Laravel/RequireCustomAbortMessageSniff.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/RequireCustomAbortMessageSniff.php
@@ -30,7 +30,7 @@ final class RequireCustomAbortMessageSniff implements Sniff
     }
 
     /** @param int $functionPointer */
-    public function process(File $phpcsFile, $functionPointer): void // phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded, SlevomatCodingStandard.Functions.FunctionLength.FunctionLength, SlevomatCodingStandard.Files.FunctionLength.FunctionLength, SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh
+    public function process(File $phpcsFile, $functionPointer): void // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh,SlevomatCodingStandard.Functions.FunctionLength.FunctionLength
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/IxDFCodingStandard/Sniffs/NamingConventions/MeaningfulVariableNameSniff.php
+++ b/IxDFCodingStandard/Sniffs/NamingConventions/MeaningfulVariableNameSniff.php
@@ -12,7 +12,20 @@ use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 final class MeaningfulVariableNameSniff extends AbstractVariableSniff
 {
     /** @var array<string, string> */
-    public array $forbiddenNames = [];
+    public array $forbiddenNames = [
+        // type-like names
+        'bool' => 'Provide more context',
+        'boolean' => 'Provide more context',
+        'int' => 'Provide more context',
+        'integer' => 'Provide more context',
+        'float' => 'Provide more context',
+        'double' => 'Provide more context',
+        'str' => 'Provide more context',
+        'var' => 'Provide more context',
+        'arr' => 'Provide more context',
+        'col' => 'Provide more context',
+        'coll' => 'Provide more context',
+    ];
 
     /**
      * Processes this test, when one of its tokens is encountered.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "phpcodesniffer-standard",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "slevomat/coding-standard": "^8.23",
         "squizlabs/php_codesniffer": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "require": {
         "php": "^8.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "slevomat/coding-standard": "^8.22",
-        "squizlabs/php_codesniffer": "^3.13"
+        "slevomat/coding-standard": "^8.23",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.87",
-        "phpunit/phpunit": "^11 || ^12",
-        "vimeo/psalm": "^6.12"
+        "phpunit/phpunit": "^12.3",
+        "vimeo/psalm": "^6.13"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Plus:
 - custom helper classes (empty ones ATM, but too to have a SSoT for next steps)
 - Use healthy defaults for MeaningfulVariableNameSniff
 - Require PHP 8.3 and higher