### PR TITLE
Add PHP-CS-Fixer Config and Rules classes

### DIFF
--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -72,7 +72,6 @@ return [
     'normalize_index_brace' => true,
     'nullable_type_declaration' => ['syntax' => 'question_mark'],
     'nullable_type_declaration_for_default_null_value' => true,
-    'numeric_literal_separator' => ['strategy' => 'use_separator', 'override_existing' => true],
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['imports_order' => ['class', 'function', 'const']],
     /*

--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -21,7 +21,7 @@ return [
     'array_indentation' => true,
     'assign_null_coalescing_to_coalesce_equal' => true,
     'binary_operator_spaces' => ['default' => 'single_space'],
-    'blank_line_before_statement' => ['statements' => ['continue', 'declare', 'return', 'throw', 'try']],
+    'blank_line_before_statement' => ['statements' => ['continue', 'declare', 'try']],
     'cast_spaces' => ['space' => 'single'],
     'class_attributes_separation' => ['elements' => ['method' => 'one']],
     'declare_strict_types' => true,

--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -21,6 +21,7 @@ return [
     'array_indentation' => true,
     'assign_null_coalescing_to_coalesce_equal' => true,
     'binary_operator_spaces' => ['default' => 'single_space'],
+    'blank_line_before_statement' => ['statements' => ['continue', 'declare', 'return', 'throw', 'try']],
     'cast_spaces' => ['space' => 'single'],
     'class_attributes_separation' => ['elements' => ['method' => 'one']],
     'declare_strict_types' => true,
@@ -44,8 +45,10 @@ return [
     ],
     'modernize_types_casting' => true,
     'mb_str_functions' => true,
+    'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
     'no_alias_functions' => true,
     'no_binary_string' => true,
+    'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
     'no_empty_comment' => true,
     'no_empty_phpdoc' => true,
     'no_empty_statement' => true,
@@ -69,7 +72,10 @@ return [
     'no_whitespace_before_comma_in_array' => true,
     'normalize_index_brace' => true,
     'nullable_type_declaration' => ['syntax' => 'question_mark'],
+    'nullable_type_declaration_for_default_null_value' => true,
+    'numeric_literal_separator' => ['strategy' => 'use_separator', 'override_existing' => true],
     'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['imports_order' => ['class', 'function', 'const']],
     /*
      * @see https://github.com/slevomat/coding-standard/issues/1620#issuecomment-1758006718
      * 'ordered_class_elements' => [

--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -48,7 +48,6 @@ return [
     'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
     'no_alias_functions' => true,
     'no_binary_string' => true,
-    'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
     'no_empty_comment' => true,
     'no_empty_phpdoc' => true,
     'no_empty_statement' => true,

--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -21,7 +21,6 @@ return [
     'array_indentation' => true,
     'assign_null_coalescing_to_coalesce_equal' => true,
     'binary_operator_spaces' => ['default' => 'single_space'],
-    'blank_line_before_statement' => ['statements' => ['continue', 'declare', 'try']],
     'cast_spaces' => ['space' => 'single'],
     'class_attributes_separation' => ['elements' => ['method' => 'one']],
     'declare_strict_types' => true,

--- a/IxDFCodingStandard/PhpCsFixer/Config.php
+++ b/IxDFCodingStandard/PhpCsFixer/Config.php
@@ -8,19 +8,13 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 /**
  * Pre-configured PHP-CS-Fixer config factory for IxDF projects.
- *
  * @see README.md for usage examples
  */
 final class Config
 {
-    /**
-     * @param array<string, mixed> $ruleOverrides Rules to merge on top of the shared ruleset
-     */
-    public static function create(
-        string $projectDir,
-        array $ruleOverrides = [],
-        ?Finder $finder = null,
-    ): BaseConfig {
+    /** @param array<string, mixed> $ruleOverrides Rules to merge on top of the shared ruleset */
+    public static function create(string $projectDir, array $ruleOverrides = [], ?Finder $finder = null): BaseConfig
+    {
         $finder ??= self::defaultFinder($projectDir);
 
         return (new BaseConfig())

--- a/IxDFCodingStandard/PhpCsFixer/Config.php
+++ b/IxDFCodingStandard/PhpCsFixer/Config.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\PhpCsFixer;
+
+use PhpCsFixer\Config as BaseConfig;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+/**
+ * Pre-configured PHP-CS-Fixer config factory for IxDF projects.
+ *
+ * @see README.md for usage examples
+ */
+final class Config
+{
+    /**
+     * @param array<string, mixed> $ruleOverrides Rules to merge on top of the shared ruleset
+     */
+    public static function create(
+        string $projectDir,
+        array $ruleOverrides = [],
+        ?Finder $finder = null,
+    ): BaseConfig {
+        $finder ??= self::defaultFinder($projectDir);
+
+        return (new BaseConfig())
+            ->setParallelConfig(ParallelConfigFactory::detect())
+            ->setUsingCache(true)
+            ->setCacheFile($projectDir.'/.cache/.php-cs-fixer.cache')
+            ->setRiskyAllowed(true)
+            ->setIndent('    ')
+            ->setLineEnding("\n")
+            ->setRules(array_merge(Rules::get(), $ruleOverrides))
+            ->setFinder($finder);
+    }
+
+    private static function defaultFinder(string $projectDir): Finder
+    {
+        return Finder::create()
+            ->in($projectDir)
+            ->exclude([
+                '.cache',
+                '.docker',
+                'bootstrap/cache',
+                'node_modules',
+                'public',
+                'storage',
+                'vendor',
+            ])
+            ->name('*.php')
+            ->notName('*.blade.php')
+            ->notName('_ide_helper.php')
+            ->notName('.phpstorm.meta.php')
+            ->ignoreDotFiles(false)
+            ->ignoreVCS(true)
+            ->ignoreVCSIgnored(true);
+    }
+}

--- a/IxDFCodingStandard/PhpCsFixer/Config.php
+++ b/IxDFCodingStandard/PhpCsFixer/Config.php
@@ -12,7 +12,8 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
  */
 final class Config
 {
-    /** @param array<string, mixed> $ruleOverrides Rules to merge on top of the shared ruleset */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+    /** @param array<string, array<string, mixed>|bool> $ruleOverrides Rules to merge on top of the shared ruleset */
     public static function create(string $projectDir, array $ruleOverrides = [], ?Finder $finder = null): BaseConfig
     {
         $finder ??= self::defaultFinder($projectDir);

--- a/IxDFCodingStandard/PhpCsFixer/Rules.php
+++ b/IxDFCodingStandard/PhpCsFixer/Rules.php
@@ -4,7 +4,6 @@ namespace IxDFCodingStandard\PhpCsFixer;
 
 /**
  * Shared PHP-CS-Fixer rules for IxDF projects.
- *
  * @see https://mlocati.github.io/php-cs-fixer-configurator/
  */
 final class Rules

--- a/IxDFCodingStandard/PhpCsFixer/Rules.php
+++ b/IxDFCodingStandard/PhpCsFixer/Rules.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\PhpCsFixer;
+
+/**
+ * Shared PHP-CS-Fixer rules for IxDF projects.
+ *
+ * @see https://mlocati.github.io/php-cs-fixer-configurator/
+ */
+final class Rules
+{
+    /** @var array<string, mixed>|null */
+    private static ?array $rules = null;
+
+    /** @return array<string, mixed> */
+    public static function get(): array
+    {
+        return self::$rules ??= require dirname(__DIR__, 2).'/.php-cs-fixer-rules.php';
+    }
+}

--- a/IxDFCodingStandard/PhpCsFixer/Rules.php
+++ b/IxDFCodingStandard/PhpCsFixer/Rules.php
@@ -8,10 +8,12 @@ namespace IxDFCodingStandard\PhpCsFixer;
  */
 final class Rules
 {
-    /** @var array<string, mixed>|null */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+    /** @var array<string, array<string, mixed>|bool>|null */
     private static ?array $rules = null;
 
-    /** @return array<string, mixed> */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+    /** @return array<string, array<string, mixed>|bool> */
     public static function get(): array
     {
         return self::$rules ??= require dirname(__DIR__, 2).'/.php-cs-fixer-rules.php';

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 # IxDF Coding Standard
 
-An opinionated coding standard for PHP/Laravel projects. Provides **PHP_CodeSniffer** rules and a shared **PHP-CS-Fixer** configuration.
+An opinionated coding standard for PHP/Laravel projects. Provides two independent tools — use either one or both together:
+
+- **PHP_CodeSniffer** — custom sniffs for strict types and Laravel conventions
+- **PHP-CS-Fixer** — shared config with 80+ rules based on PER-CS 3.0
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,22 @@ $rules = \IxDFCodingStandard\PhpCsFixer\Rules::get();
 
 ## Usage
 
+Add composer scripts to your `composer.json`:
+
+```json
+"scripts": {
+    "cs:check": "phpcs -p -s --colors --report-full --report-summary",
+    "cs:fix": "phpcbf -p --colors",
+    "cs-fixer:check": "php-cs-fixer fix --dry-run --diff",
+    "cs-fixer:fix": "php-cs-fixer fix"
+}
+```
+
+Then run:
+
 ```shell
-composer cs:check   # check only
-composer cs:fix     # auto-fix
+composer cs:check        # PHP_CodeSniffer: check only
+composer cs:fix          # PHP_CodeSniffer: auto-fix
+composer cs-fixer:check  # PHP-CS-Fixer: check only
+composer cs-fixer:fix    # PHP-CS-Fixer: auto-fix
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,16 @@ $rules = \IxDFCodingStandard\PhpCsFixer\Rules::get();
 
 ## Usage
 
-Add composer scripts to your `composer.json`:
+```shell
+vendor/bin/phpcs          # check with PHP_CodeSniffer
+vendor/bin/phpcbf         # fix with PHP_CodeSniffer
+vendor/bin/php-cs-fixer fix --dry-run --diff   # check with PHP-CS-Fixer
+vendor/bin/php-cs-fixer fix                    # fix with PHP-CS-Fixer
+```
+
+### Composer scripts (recommended)
+
+Add to your `composer.json`:
 
 ```json
 "scripts": {

--- a/README.md
+++ b/README.md
@@ -3,107 +3,70 @@
 [![PHP Psalm Level](https://shepherd.dev/github/InteractionDesignFoundation/coding-standard/level.svg)](https://shepherd.dev/github/InteractionDesignFoundation/coding-standard)
 [![PHP Psalm Type Coverage](https://shepherd.dev/github/InteractionDesignFoundation/coding-standard/coverage.svg)](https://shepherd.dev/github/InteractionDesignFoundation/coding-standard)
 
-# IxDF Coding Standard for Laravel
+# IxDF Coding Standard
 
-An opinionated ruleset focused on strict types.
-Suitable for both applications and packages.
+An opinionated coding standard for PHP/Laravel projects. Provides **PHP_CodeSniffer** rules and a shared **PHP-CS-Fixer** configuration.
 
 ## Installation
 
-1. Install the package via composer by running:
 ```shell
 composer require --dev interaction-design-foundation/coding-standard
 ```
 
-2. Add composer scripts into your `composer.json`:
-```json
-"scripts": {
-  "cs:check": "phpcs -p -s --colors --report-full --report-summary",
-  "cs:fix": "phpcbf -p --colors"
-}
-```
+## PHP_CodeSniffer
 
-3. Create file `phpcs.xml` on the base path of your repository with content
+Create `phpcs.xml` in your project root:
 ```xml
 <?xml version="1.0"?>
 <ruleset name="My Coding Standard">
-    <!-- Include all rules from the IxDF Coding Standard -->
     <rule ref="IxDFCodingStandard"/>
-
-    <!-- Paths to check -->
     <file>app</file>
     <file>config</file>
     <file>database</file>
-    <file>lang</file>
     <file>routes</file>
     <file>tests</file>
 </ruleset>
 ```
 
+## PHP-CS-Fixer
+
+Create `.php-cs-fixer.php` in your project root:
+
+```php
+<?php declare(strict_types=1);
+
+use IxDFCodingStandard\PhpCsFixer\Config;
+
+return Config::create(__DIR__);
+```
+
+With rule overrides:
+
+```php
+return Config::create(__DIR__, ruleOverrides: [
+    'final_public_method_for_abstract_class' => false,
+]);
+```
+
+With a custom Finder:
+
+```php
+use IxDFCodingStandard\PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()->in(__DIR__)->name('*.php');
+
+return Config::create(__DIR__, finder: $finder);
+```
+
+If you only need the rules array:
+```php
+$rules = \IxDFCodingStandard\PhpCsFixer\Rules::get();
+```
+
 ## Usage
 
-- To run checks only:
-
 ```shell
-composer cs:check
+composer cs:check   # check only
+composer cs:fix     # auto-fix
 ```
-
-- To automatically fix many CS issues:
-
-```shell
-composer cs:fix
-```
-
-## Ignoring parts of a File
-
-Disable parts of a file:
-
-```php
-$xmlPackage = new XMLPackage;
-// phpcs:disable
-$xmlPackage['error_code'] = get_default_error_code_value();
-$xmlPackage->send();
-// phpcs:enable
-```
-
-Disable a specific rule:
-
-```php
-// phpcs:disable Generic.Commenting.Todo.Found
-$xmlPackage = new XMLPackage;
-$xmlPackage['error_code'] = get_default_error_code_value();
-// TODO: Add an error message here.
-$xmlPackage->send();
-// phpcs:enable
-```
-
-Ignore a specific violation:
-
-```php
-$xmlPackage = new XMLPackage;
-$xmlPackage['error_code'] = get_default_error_code_value();
-// phpcs:ignore Generic.Commenting.Todo.Found
-// TODO: Add an error message here.
-$xmlPackage->send();
-```
-
-## Development
-
-### Versioning
-> **New rules or Sniffs may not be introduced in minor or bugfix releases and should always be based on the develop
-branch and queued for the next major release, unless considered a bugfix for existing rules.**
-
-
-## Reference
-
-Rules can be added, excluded or tweaked locally, depending on your preferences.
-More information on how to do this can be found here:
-
-- [Coding Standard Tutorial](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial)
-- [Configuration Options](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options)
-- [Selectively Applying Rules](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset#selectively-applying-rules)
-- [Customisable Sniff Properties](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties)
-- Other coding standards (inspiring us):
-  - [Slevomat coding standard](https://github.com/slevomat/coding-standard)
-  - [Doctrine coding standard](https://github.com/doctrine/coding-standard)
-  - [Laminas coding standard](https://github.com/laminas/laminas-coding-standard)

--- a/README.md
+++ b/README.md
@@ -73,18 +73,21 @@ Add composer scripts to your `composer.json`:
 
 ```json
 "scripts": {
-    "cs:check": "phpcs -p -s --colors --report-full --report-summary",
-    "cs:fix": "phpcbf -p --colors",
-    "cs-fixer:check": "php-cs-fixer fix --dry-run --diff",
-    "cs-fixer:fix": "php-cs-fixer fix"
+    "cs": "@cs:fix",
+    "cs:check": ["@php-cs-fixer:dry", "@phpcs"],
+    "cs:fix": ["@php-cs-fixer", "@phpcbf"],
+    "phpcs": "phpcs -p -s --colors --report-full --report-summary",
+    "phpcbf": "phpcbf -p --colors",
+    "php-cs-fixer": "php-cs-fixer fix --no-interaction --ansi --quiet",
+    "php-cs-fixer:dry": "php-cs-fixer fix --no-interaction --ansi --verbose --dry-run"
 }
 ```
 
 Then run:
 
 ```shell
-composer cs:check        # PHP_CodeSniffer: check only
-composer cs:fix          # PHP_CodeSniffer: auto-fix
-composer cs-fixer:check  # PHP-CS-Fixer: check only
-composer cs-fixer:fix    # PHP-CS-Fixer: auto-fix
+composer cs:check       # run both tools in check mode
+composer cs:fix         # run both tools in fix mode
+composer phpcs          # PHP_CodeSniffer only
+composer php-cs-fixer   # PHP-CS-Fixer only
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
     "name": "interaction-design-foundation/coding-standard",
-    "description": "IxDF Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+    "description": "IxDF coding standard: PHP_CodeSniffer rules and shared PHP-CS-Fixer configuration.",
     "license": "MIT",
     "type": "phpcodesniffer-standard",
     "require": {
         "php": "^8.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "friendsofphp/php-cs-fixer": "^3.89",
         "slevomat/coding-standard": "^8.25",
         "squizlabs/php_codesniffer": "^4.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.89",
         "phpunit/phpunit": "^12.4",
         "vimeo/psalm": "^6.13"
     },


### PR DESCRIPTION
## Summary

- Added `IxDFCodingStandard\PhpCsFixer\Config` factory class for creating pre-configured PHP-CS-Fixer configs
- Added `IxDFCodingStandard\PhpCsFixer\Rules` class that exposes shared rules via `Rules::get()`
- Moved `friendsofphp/php-cs-fixer` from `require-dev` to `require` (needed for the public API)
- Updated README with usage examples

### Before (hacky vendor path require):
```php
$rules = require __DIR__.'/vendor/interaction-design-foundation/coding-standard/.php-cs-fixer-rules.php';
// ...20 lines of boilerplate config...
```

### After:
```php
use IxDFCodingStandard\PhpCsFixer\Config;
return Config::create(__DIR__);
```

The old `.php-cs-fixer-rules.php` file is kept for backward compatibility.
