### PR TITLE
Prevent ForbidMethodDeclaration sniff aborting on deprecated traits

### DIFF
--- a/IxDFCodingStandard/Sniffs/Classes/ForbidMethodDeclarationSniff.php
+++ b/IxDFCodingStandard/Sniffs/Classes/ForbidMethodDeclarationSniff.php
@@ -31,11 +31,8 @@ final class ForbidMethodDeclarationSniff implements Sniff
         $fqcn = ClassHelper::getFullyQualifiedName($phpcsFile, $classPointer);
         foreach ($this->forbiddenMethods as $typeAndMethod => $replacement) {
             [$type, $method] = explode('::', $typeAndMethod);
-            if (! is_subclass_of($fqcn, $type)) {
-                continue;
-            }
 
-            if (! method_exists($fqcn, $method)) {
+            if (! $this->declaresForbiddenMethod($fqcn, $type, $method)) {
                 continue;
             }
 
@@ -44,6 +41,22 @@ final class ForbidMethodDeclarationSniff implements Sniff
                 $classPointer,
                 self::FORBIDDEN_METHOD_DECLARATION
             );
+        }
+    }
+
+    /** @param class-string $fqcn */
+    private function declaresForbiddenMethod(string $fqcn, string $type, string $method): bool
+    {
+        // is_subclass_of()/method_exists() autoload $fqcn. The analysed class may use a deprecated trait
+        // or extend a deprecated class, which emits a deprecation on PHP 8.5+ (e.g. "Trait X used by Y is
+        // deprecated"). That deprecation is a side effect of the analysed code, not of this sniff, and would
+        // otherwise be turned into an exception that aborts the whole file check, so it is silenced here.
+        set_error_handler(static fn(): bool => true, \E_DEPRECATED | \E_USER_DEPRECATED);
+
+        try {
+            return is_subclass_of($fqcn, $type) && method_exists($fqcn, $method);
+        } finally {
+            restore_error_handler();
         }
     }
 }

--- a/tests/Sniffs/Classes/ForbidMethodDeclarationSniffTest.php
+++ b/tests/Sniffs/Classes/ForbidMethodDeclarationSniffTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Sniffs\Classes;
+
+use IxDFCodingStandard\Sniffs\Classes\data\ForbidMethodDeclarationSniff\ForbiddenParent;
+use IxDFCodingStandard\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ForbidMethodDeclarationSniff::class)]
+final class ForbidMethodDeclarationSniffTest extends TestCase
+{
+    private const FORBIDDEN_METHODS = [
+        ForbiddenParent::class.'::shouldSend' => '\App\Notifications\Support\ShouldCheckConditionsBeforeSendingOut::shouldBeSent',
+    ];
+
+    #[Test]
+    #[RequiresPhp('>= 8.5.0')]
+    public function it_reports_forbidden_method_even_when_the_class_uses_a_deprecated_trait(): void
+    {
+        // #[\Deprecated] is only allowed on traits since PHP 8.5 (earlier versions reject the fixture at compile time).
+        // Resolving the class autoloads it; using a deprecated trait then emits a deprecation, and the sniff must
+        // silence it instead of letting it abort the whole file check (Internal.Exception).
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+
+                return true;
+            },
+            \E_DEPRECATED | \E_USER_DEPRECATED
+        );
+
+        try {
+            $report = self::checkFile(
+                __DIR__.'/data/ForbidMethodDeclarationSniff/ChildDeclaringForbiddenMethod.php',
+                ['forbiddenMethods' => self::FORBIDDEN_METHODS]
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame([], $deprecations, 'The sniff must not leak deprecations triggered while autoloading the analysed class.');
+        self::assertSame(1, $report->getErrorCount());
+        self::assertSniffError($report, 5, ForbidMethodDeclarationSniff::FORBIDDEN_METHOD_DECLARATION);
+    }
+
+    #[Test]
+    public function it_does_not_report_when_the_subclass_does_not_declare_the_forbidden_method(): void
+    {
+        $report = self::checkFile(
+            __DIR__.'/data/ForbidMethodDeclarationSniff/ChildWithoutForbiddenMethod.php',
+            ['forbiddenMethods' => self::FORBIDDEN_METHODS]
+        );
+
+        self::assertNoSniffErrorInFile($report);
+    }
+}

--- a/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ChildDeclaringForbiddenMethod.php
+++ b/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ChildDeclaringForbiddenMethod.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Sniffs\Classes\data\ForbidMethodDeclarationSniff;
+
+final class ChildDeclaringForbiddenMethod extends ForbiddenParent
+{
+    use DeprecatedTrait;
+
+    public function shouldSend(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ChildWithoutForbiddenMethod.php
+++ b/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ChildWithoutForbiddenMethod.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Sniffs\Classes\data\ForbidMethodDeclarationSniff;
+
+final class ChildWithoutForbiddenMethod extends ForbiddenParent
+{
+    public function send(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/DeprecatedTrait.php
+++ b/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/DeprecatedTrait.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Sniffs\Classes\data\ForbidMethodDeclarationSniff;
+
+#[\Deprecated(message: 'Use composition instead.')]
+trait DeprecatedTrait
+{
+}

--- a/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ForbiddenParent.php
+++ b/tests/Sniffs/Classes/data/ForbidMethodDeclarationSniff/ForbiddenParent.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\Sniffs\Classes\data\ForbidMethodDeclarationSniff;
+
+class ForbiddenParent
+{
+}


### PR DESCRIPTION
## Problem

On PHP 8.5 the `#[\Deprecated]` attribute is now honoured on traits. Loading a class that uses a deprecated trait emits a runtime deprecation (e.g. `Trait X used by Y is deprecated, ...`). In PHP 8.4 the attribute on a trait was a no-op, so nothing fired.

`ForbidMethodDeclarationSniff::process()` resolves the analysed class via `is_subclass_of()` / `method_exists()`, both of which autoload it. That autoload materialises the deprecated-trait usage, the deprecation fires, PHP_CodeSniffer turns it into an exception, and the whole file check aborts:

```
error - An error occurred during processing; checking has been aborted.
The error message was: Trait App\Http\Requests\RequestInviteAware used by
App\Http\Requests\InviteAwareRequest is deprecated, Please inject services
instead. ... The error originated in the
IxDFCodingStandard.Classes.ForbidMethodDeclaration sniff on line 34.
(Internal.Exception)
```

Any class under analysis that uses a `#[\Deprecated]` trait (or extends a deprecated class) hits this.

## Fix

The deprecation is a side effect of the analysed code, not an issue with the sniff, so the sniff must not let it abort the run. The two reflection calls are moved into a private helper that silences `E_DEPRECATED` / `E_USER_DEPRECATED` (via a scoped `set_error_handler` restored in a `finally`) while resolving the class. Behaviour is otherwise identical.

## Tests

Added `ForbidMethodDeclarationSniffTest` with fixtures where the analysed class uses a `#[\Deprecated]` trait. The regression test installs its own deprecation-capturing handler around the run and asserts none leak, so it fails on the unpatched sniff (with the exact PHP 8.5 trait-deprecation message) and passes after the fix. Verified against the real IxDF-web codebase: a full `phpcs` scan goes from 10 `Internal.Exception` failures to a clean run.