### PR TITLE
Improve PHP-CS-Fixer config sharing, require PHP 8.4, and slim PHP_CodeSniffer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
-          - "8.3"
           - "8.4"
           - "8.5"
         operating-system:

--- a/.php-cs-fixer-rules.php
+++ b/.php-cs-fixer-rules.php
@@ -3,13 +3,19 @@
 /**
  * Shared PHP-CS-Fixer rules for PER projects.
  * @see https://localheinz.com/articles/2023/03/10/sharing-configurations-for-php-cs-fixer-across-projects/
- * How to use:
- * $rules = require __DIR__.'/vendor/interaction-design-foundation/php-cs-fixer-rules.php';
+ *
+ * Prefer the autoloaded API: \IxDFCodingStandard\PhpCsFixer\Rules::get() (or Config::create()).
+ * This raw file is the no-autoloader fallback; require it directly when needed:
+ * $rules = require __DIR__.'/vendor/interaction-design-foundation/coding-standard/.php-cs-fixer-rules.php';
  * $config->setRules($rules);
  */
 return [
     // Basic PER Coding Style 3.0 ruleset plus our overrides for it, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PER-CS3x0.rst
     '@PER-CS3x0' => true, // https://www.php-fig.org/per/coding-style/
+    // Auto-modernize syntax to the target PHP/PHPUnit version. Renovate bumps PHP-CS-Fixer, so new migration rules arrive for free.
+    '@PHP8x4Migration' => true,
+    '@PHP8x4Migration:risky' => true,
+    '@PHPUnit10x0Migration:risky' => true,
     'new_with_parentheses' => ['anonymous_class' => true], // It will be changed in PHP-CS-Fixer v4.0 (but we want to enforce it), see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8148
     // overrides for PER-CS2.0/PER-CS3.0
     'concat_space' => ['spacing' => 'none'], // make strings shorter "'hello' . $name . '!'" => "'hello'.$name.'!'"
@@ -71,6 +77,7 @@ return [
     'normalize_index_brace' => true,
     'nullable_type_declaration' => ['syntax' => 'question_mark'],
     'nullable_type_declaration_for_default_null_value' => true,
+    'numeric_literal_separator' => ['strategy' => 'use_separator', 'override_existing' => false],
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['imports_order' => ['class', 'function', 'const']],
     /*

--- a/IxDFCodingStandard/PhpCsFixer/Config.php
+++ b/IxDFCodingStandard/PhpCsFixer/Config.php
@@ -9,6 +9,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 /**
  * Pre-configured PHP-CS-Fixer config factory for IxDF projects.
  * @see README.md for usage examples
+ * @api
  */
 final class Config
 {

--- a/IxDFCodingStandard/PhpCsFixer/Rules.php
+++ b/IxDFCodingStandard/PhpCsFixer/Rules.php
@@ -5,6 +5,7 @@ namespace IxDFCodingStandard\PhpCsFixer;
 /**
  * Shared PHP-CS-Fixer rules for IxDF projects.
  * @see https://mlocati.github.io/php-cs-fixer-configurator/
+ * @api
  */
 final class Rules
 {

--- a/IxDFCodingStandard/ruleset.xml
+++ b/IxDFCodingStandard/ruleset.xml
@@ -13,13 +13,6 @@
     <arg value="s"/>
     <arg name="report-width" value="120"/>
 
-    <!-- PSR2 ruleset: -->
-    <!-- Disallow else if in favor of elseif -->
-    <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
-        <type>error</type>
-    </rule>
-    <!-- PSR2 ruleset end. -->
-
     <!-- PSR12 ruleset (includes PSR1 + most of PSR2 + some Generic rules). -->
     <rule ref="PSR12">
         <!-- Not ready for readonly classes (PHP 8.2) -->
@@ -49,16 +42,20 @@
         <exclude name="PSR12.Traits.UseDeclaration"/>
         <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceAfterNullabilitySymbol -->
         <exclude name="PSR12.Functions.NullableTypeDeclaration.WhitespaceFound"/>
+
+        <!-- The rules below are fixed by PHP-CS-Fixer (faster, auto-fixing); no need to also check them here. -->
+        <!-- fixed by PHP-CS-Fixer indentation_type + statement_indentation -->
+        <exclude name="Generic.WhiteSpace.ScopeIndent"/>
+        <!-- fixed by PHP-CS-Fixer no_trailing_whitespace + no_whitespace_in_blank_line + no_extra_blank_lines -->
+        <exclude name="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+        <!-- fixed by PHP-CS-Fixer elseif -->
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration"/>
+        <!-- fixed by PHP-CS-Fixer full_opening_tag -->
+        <exclude name="Generic.PHP.DisallowShortOpenTag"/>
     </rule>
     <!-- PSR12 ruleset end. -->
 
     <!-- Generic ruleset: -->
-    <!-- Force array element indentation with 4 spaces -->
-    <rule ref="Generic.Arrays.ArrayIndent">
-        <exclude name="Generic.Arrays.ArrayIndent.CloseBraceNotNewLine"/>
-    </rule>
-    <!-- Forbid `array(...)` -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <!-- Forbid duplicate classes -->
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <!-- Forbid empty statements -->
@@ -68,8 +65,6 @@
     </rule>
     <!-- Warn about variable assignments inside conditions -->
     <rule ref="Generic.CodeAnalysis.AssignmentInCondition"/>
-    <!-- Forbid final methods in final classes -->
-    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <!-- Forbid useless empty method overrides -->
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <!-- Detects the usage of one and the same incrementer into an outer and an inner -->
@@ -86,8 +81,6 @@
     </rule>
     <!-- Ensure there is a single class/interface/trait per file -->
     <rule ref="Generic.Files.OneObjectStructurePerFile"/>
-    <!-- Force whitespace after a type cast -->
-    <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <!--
     <rule ref="Generic.Formatting.SpaceAfterNot"/>&lt;!&ndash; Force whitespace after `!` &ndash;&gt;
     -->
@@ -107,8 +100,6 @@
     <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
     <!-- Forbid deprecated functions -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <!-- Forbid short open tag -->
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
     <!-- Array values are specified by using a string representation of the array. -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
@@ -163,18 +154,12 @@
     <rule ref="Generic.VersionControl.GitMergeConflict"/>
     <!-- Generic ruleset end. -->
 
-    <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/3875 , remove the exclusion when then fix it released plus update min version -->
-    <rule ref="Generic.WhiteSpace.ScopeIndent">
-        <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact"/>
-    </rule>
-
     <!-- SlevomatCoding ruleset: -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
     <!-- Array must have keys specified for either all or none of the values. -->
     <rule ref="SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed"/>
     <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
-    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing">
         <!-- For code like private function processUser(Member $member, #[\SensitiveParameter] string $password): void -->
         <exclude name="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing.IncorrectLinesCountBetweenAttributeAndTarget"/>
@@ -188,8 +173,6 @@
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
-    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
-    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition"/>
     <rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch"/>
     <rule ref="SlevomatCodingStandard.Classes.EnumCaseSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.MethodSpacing"/>
@@ -220,7 +203,6 @@
             <property name="linesCountBetweenAnnotationsGroups" value="0"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
         <properties>
@@ -248,18 +230,13 @@
     </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
-    <!-- Requires new with parentheses. -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator">
         <properties>
             <property name="lineLengthLimit" value="120"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireSingleLineCondition"/>
@@ -301,7 +278,6 @@
     <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation">
         <properties>
@@ -311,7 +287,6 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
     <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
@@ -321,7 +296,6 @@
         </properties>
         <severity>6</severity>
     </rule>
-    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
         <properties>
@@ -330,7 +304,6 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
-    <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
     <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>
     <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing"/>
@@ -345,9 +318,6 @@
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
-    <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
-    <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
-    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
@@ -359,7 +329,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <!-- Native type hints may break inheritance -->
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
@@ -416,8 +385,6 @@
     <!-- SlevomatCoding end. -->
 
     <!-- Squiz ruleset: -->
-    <!-- Don't use a space like $array [$key] -->
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <!-- Checks for empty catch clause without a comment. -->
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
     <!-- Force phpDoc alignment -->
@@ -486,43 +453,10 @@
     <rule ref="Squiz.Scope.MemberVarScope"/>
     <!-- Checks for usage of $this in static methods, which will cause runtime errors. -->
     <rule ref="Squiz.Scope.StaticThisUsage"/>
-    <!-- Makes sure there are no spaces around the concatenation operator. -->
-    <rule ref="Squiz.Strings.ConcatenationSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
     <!-- Use singular quotes by default -->
     <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
     <!-- Forbid braces around string in `echo` -->
     <rule ref="Squiz.Strings.EchoedStrings"/>
-    <!-- Require space around logical operators -->
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-    <!-- Forbid superfluous whitespaces -->
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <!-- Turned on by PSR2 -> turning back off -->
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
-    <!-- Forbid spaces around `->` operator -->
-    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
-    <!-- It's like PRS-12 OperatorSpacing rule, but has do not check for concatenation -->
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
-    <!-- Forbid spaces before semicolon `;` -->
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
-        <!-- Turned off by PSR2 -> turning back on -->
-        <severity>5</severity>
-    </rule>
     <!-- Squiz ruleset end. -->
 
     <!--IxDFCodingStandard custom rules: -->

--- a/IxDFCodingStandard/ruleset.xml
+++ b/IxDFCodingStandard/ruleset.xml
@@ -13,47 +13,16 @@
     <arg value="s"/>
     <arg name="report-width" value="120"/>
 
-    <!-- PSR12 ruleset (includes PSR1 + most of PSR2 + some Generic rules). -->
-    <rule ref="PSR12">
-        <!-- Not ready for readonly classes (PHP 8.2) -->
+    <!--
+        PSR1/PSR12 formatting is fully covered by PHP-CS-Fixer's @PER-CS3x0 (PER-CS is the successor to PSR-12),
+        so we do not run the PSR12 sniffs here. We keep only the PSR1 structural sniffs that PHP-CS-Fixer cannot enforce.
+    -->
+    <rule ref="PSR1.Files.SideEffects">
+        <!-- A file may both declare symbols and have side effects (e.g. Laravel routes/config). -->
         <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
-
-        <!-- Need to exclude concatenation rule but there is no such option :( -->
-        <exclude name="PSR12.Operators.OperatorSpacing"/>
-        <!-- We use <?php declare(strict_types=1);\n as more readable option -->
-        <exclude name="PSR12.Files.OpenTag.NotAlone"/>
-        <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
-        <exclude name="PSR12.Files.FileHeader"/>
-        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
-
-        <!-- Conflicts with PHP-CS-Fixer's single_line_empty_body from PER2x0-->
-        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
-        <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
-        <!-- checked by SlevomatCodingStandard.Namespaces.UseSpacing -->
-        <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
-        <!-- checked by SlevomatCodingStandard.Namespaces.NamespaceSpacing -->
-        <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
-        <!-- checked by SlevomatCodingStandard.Operators.SpreadOperatorSpacing -->
-        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterVariadic"/>
-        <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing -->
-        <exclude name="PSR12.Functions.ReturnTypeDeclaration"/>
-        <!-- checked by SlevomatCodingStandard.Classes.TraitUseSpacing -->
-        <exclude name="PSR12.Traits.UseDeclaration"/>
-        <!-- checked by SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceAfterNullabilitySymbol -->
-        <exclude name="PSR12.Functions.NullableTypeDeclaration.WhitespaceFound"/>
-
-        <!-- The rules below are fixed by PHP-CS-Fixer (faster, auto-fixing); no need to also check them here. -->
-        <!-- fixed by PHP-CS-Fixer indentation_type + statement_indentation -->
-        <exclude name="Generic.WhiteSpace.ScopeIndent"/>
-        <!-- fixed by PHP-CS-Fixer no_trailing_whitespace + no_whitespace_in_blank_line + no_extra_blank_lines -->
-        <exclude name="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-        <!-- fixed by PHP-CS-Fixer elseif -->
-        <exclude name="PSR2.ControlStructures.ElseIfDeclaration"/>
-        <!-- fixed by PHP-CS-Fixer full_opening_tag -->
-        <exclude name="Generic.PHP.DisallowShortOpenTag"/>
     </rule>
-    <!-- PSR12 ruleset end. -->
+    <rule ref="PSR1.Classes.ClassDeclaration"/>
+    <rule ref="PSR1.Methods.CamelCapsMethodName"/>
 
     <!-- Generic ruleset: -->
     <!-- Forbid duplicate classes -->
@@ -365,6 +334,8 @@
             <property name="traversableTypeHints" type="array">
                 <element value="\Illuminate\Database\Eloquent\Collection"/>
                 <element value="\Illuminate\Support\Collection"/>
+                <element value="\Illuminate\Support\Enumerable"/>
+                <element value="\Illuminate\Support\LazyCollection"/>
                 <element value="\Illuminate\Pagination\AbstractCursorPaginator"/>
                 <element value="\Illuminate\Pagination\AbstractPaginator"/>
                 <element value="\Illuminate\Pagination\CursorPaginator"/>

--- a/README.md
+++ b/README.md
@@ -5,30 +5,15 @@
 
 # IxDF Coding Standard
 
-An opinionated coding standard for PHP/Laravel projects. Provides two independent tools — use either one or both together:
+An opinionated coding standard for PHP/Laravel projects. It ships two independent tools that you can use separately or together:
 
-- **PHP_CodeSniffer** — custom sniffs for strict types and Laravel conventions
-- **PHP-CS-Fixer** — shared config with 80+ rules based on PER-CS 3.0
+- **PHP-CS-Fixer** — shared config based on the [latest PER Coding Style](https://www.php-fig.org/per/coding-style/) (currently PER-CS 3.0), plus formatting and modernization rules.
+- **PHP_CodeSniffer** — custom sniffs for strict types and Laravel conventions.
 
 ## Installation
 
 ```shell
 composer require --dev interaction-design-foundation/coding-standard
-```
-
-## PHP_CodeSniffer
-
-Create `phpcs.xml` in your project root:
-```xml
-<?xml version="1.0"?>
-<ruleset name="My Coding Standard">
-    <rule ref="IxDFCodingStandard"/>
-    <file>app</file>
-    <file>config</file>
-    <file>database</file>
-    <file>routes</file>
-    <file>tests</file>
-</ruleset>
 ```
 
 ## PHP-CS-Fixer
@@ -43,18 +28,17 @@ use IxDFCodingStandard\PhpCsFixer\Config;
 return Config::create(__DIR__);
 ```
 
-With rule overrides:
+`Config::create()` ships a sensible default Finder and enables parallel runs, risky rules, and caching. Two optional arguments let you adjust it:
 
 ```php
+// Override individual rules.
 return Config::create(__DIR__, ruleOverrides: [
     'final_public_method_for_abstract_class' => false,
 ]);
 ```
 
-With a custom Finder:
-
 ```php
-use IxDFCodingStandard\PhpCsFixer\Config;
+// Provide your own Finder.
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()->in(__DIR__)->name('*.php');
@@ -62,27 +46,48 @@ $finder = Finder::create()->in(__DIR__)->name('*.php');
 return Config::create(__DIR__, finder: $finder);
 ```
 
-If you only need the rules array:
+Need only the rules array (e.g. to compose your own config)?
+
 ```php
 $rules = \IxDFCodingStandard\PhpCsFixer\Rules::get();
 ```
 
-## Usage
+Run it:
 
 ```shell
-vendor/bin/phpcs          # check with PHP_CodeSniffer
-vendor/bin/phpcbf         # fix with PHP_CodeSniffer
-vendor/bin/php-cs-fixer fix --dry-run --diff   # check with PHP-CS-Fixer
-vendor/bin/php-cs-fixer fix                    # fix with PHP-CS-Fixer
+vendor/bin/php-cs-fixer fix --dry-run --diff   # check
+vendor/bin/php-cs-fixer fix                     # fix
 ```
 
-### Composer scripts (recommended)
+## PHP_CodeSniffer
 
-Add to your `composer.json`:
+Create `phpcs.xml` in your project root:
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="My Coding Standard">
+    <rule ref="IxDFCodingStandard"/>
+    <file>app</file>
+    <file>config</file>
+    <file>database</file>
+    <file>routes</file>
+    <file>tests</file>
+</ruleset>
+```
+
+Run it:
+
+```shell
+vendor/bin/phpcs    # check
+vendor/bin/phpcbf   # fix
+```
+
+## Composer scripts (recommended)
+
+Wire both tools into `composer.json` so the whole team runs them the same way:
 
 ```json
 "scripts": {
-    "cs": "@cs:fix",
     "cs:check": ["@php-cs-fixer:dry", "@phpcs"],
     "cs:fix": ["@php-cs-fixer", "@phpcbf"],
     "phpcs": "phpcs -p -s --colors --report-full --report-summary",
@@ -92,11 +97,7 @@ Add to your `composer.json`:
 }
 ```
 
-Then run:
-
 ```shell
-composer cs:check       # run both tools in check mode
-composer cs:fix         # run both tools in fix mode
-composer phpcs          # PHP_CodeSniffer only
-composer php-cs-fixer   # PHP-CS-Fixer only
+composer cs:check   # check with both tools
+composer cs:fix     # fix with both tools
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 # IxDF Coding Standard
 
-An opinionated coding standard for PHP/Laravel projects. It ships two independent tools that you can use separately or together:
+An opinionated coding standard for PHP/Laravel projects. The two tools play different roles and are meant to run together:
 
-- **PHP-CS-Fixer** — shared config based on the [latest PER Coding Style](https://www.php-fig.org/per/coding-style/) (currently PER-CS 3.0), plus formatting and modernization rules.
-- **PHP_CodeSniffer** — custom sniffs for strict types and Laravel conventions.
+- **PHP-CS-Fixer** (primary) — shared config based on the [latest PER Coding Style](https://www.php-fig.org/per/coding-style/) (currently PER-CS 3.0), plus formatting and modernization rules. It owns all code formatting and auto-fixes it.
+- **PHP_CodeSniffer** (supplementary) — adds the structural and semantic checks PHP-CS-Fixer cannot enforce (strict types, Laravel conventions, naming, complexity). Formatting rules already covered by PHP-CS-Fixer are intentionally **not** duplicated here, so PHP_CodeSniffer is not a complete standard on its own.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "phpcodesniffer-standard",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.89",
         "slevomat/coding-standard": "^8.29",

--- a/tests/PhpCsFixer/RulesTest.php
+++ b/tests/PhpCsFixer/RulesTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace IxDFCodingStandard\PhpCsFixer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Rules::class)]
+#[CoversClass(Config::class)]
+final class RulesTest extends TestCase
+{
+    #[Test]
+    public function it_returns_a_non_empty_ruleset(): void
+    {
+        self::assertNotEmpty(Rules::get());
+    }
+
+    #[Test]
+    public function it_builds_a_config_with_the_shared_rules(): void
+    {
+        $config = Config::create(__DIR__);
+
+        self::assertSame(Rules::get(), $config->getRules());
+        self::assertTrue($config->getRiskyAllowed());
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes around the PHP-CS-Fixer / PHP_CodeSniffer relationship:

1. Harden and extend the shared PHP-CS-Fixer config; bump the package to PHP 8.4.
2. Make PHP-CS-Fixer the primary tool (it owns formatting) and slim PHP_CodeSniffer down to the structural/semantic checks the fixer cannot do, removing duplicated formatting sniffs.

## PHP-CS-Fixer config

- Add migration rulesets for automatic modernization: `@PHP8x4Migration`, `@PHP8x4Migration:risky`, `@PHPUnit10x0Migration:risky`. Renovate already bumps PHP-CS-Fixer, so new migration rules arrive for free.
- Add `numeric_literal_separator` (`override_existing: false`).
- Mark `Config` and `Rules` as `@api`.
- Fix the stale raw-require example in the rules-file docblock.
- Add `tests/PhpCsFixer/RulesTest.php` (was zero coverage for the fixer config).

## PHP 8.4

- `composer.json`: `php` `^8.3` -> `^8.4`.
- `test.yml`: drop `8.3` from the matrix (kept `8.4`, `8.5`).

## PHP_CodeSniffer dedup

PHP_CodeSniffer no longer checks what PHP-CS-Fixer already fixes (the fixer is faster and auto-fixes). Removals were mapped against the expanded 151-rule effective fixer set, not by name alone.

- Removed ~30 standalone sniffs with an exact fixer equivalent (array syntax/indentation, cast and operator spacing, trailing commas, yoda style, null coalesce, short list, import ordering, etc.).
- Replaced the whole `PSR12` ref with the three PSR1 sniffs the fixer cannot enforce (`PSR1.Files.SideEffects`, `PSR1.Classes.ClassDeclaration`, `PSR1.Methods.CamelCapsMethodName`), since `@PER-CS3x0` (PER-CS supersedes PSR-12) covers all PSR12 formatting.
- Net active sniffs: 228 -> 152.
- Kept sniffs with no fixer equivalent in our config: `single_quote`, `native_function_casing`, AND/OR operators, `==` vs `===`, member var scope, annotation-aware unused imports, const/property spacing, and `Generic.CodeAnalysis.EmptyStatement` (empty control-structure bodies, distinct from stray semicolons).

## Consumer impact

PHP_CodeSniffer is now **supplementary**, not a standalone standard: projects should run both tools (formatting comes from PHP-CS-Fixer). README updated to state this.

## Verification

- `vendor/bin/phpunit`: 18 passing.
- PHP-CS-Fixer dry-run with the real ruleset resolves with no rule conflicts.
- Fixer fixtures confirm it catches the formatting concerns of the removed sniffs (scope indent, scalar casts, superfluous whitespace, PSR12 brace/spacing/switch/new-parens).
- `phpcs -e` confirms the removed sniffs are gone and the kept ones remain.