### PR TITLE
Dogfood the shared PHP-CS-Fixer config in CI

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,48 @@
+name: PHP-CS-Fixer
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: php-cs-fixer-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: 8.4
+          coverage: none
+          extensions: mbstring
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: |
+          echo "composer_dir={$(composer config cache-files-dir)}" >> $GITHUB_OUTPUT
+
+      - name: Retrieve Composer‘s cache
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+        with:
+          path: ${{ steps.composer-cache.outputs.composer_dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install composer dependencies
+        run: "composer install --no-interaction --no-progress --no-scripts"
+
+      # Dogfood: lint this package with its own shared PHP-CS-Fixer config.
+      # A hard gate (not auto-fixed) so a renamed/removed rule from a dependency bump fails loudly.
+      - name: Run PHP-CS-Fixer
+        run: composer php-cs-fixer:check

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use IxDFCodingStandard\PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+// Dogfood: lint this package with its own shared PHP-CS-Fixer configuration.
+$finder = Finder::create()
+    ->in(__DIR__)
+    ->exclude(['vendor', '.cache'])
+    // Sniff test fixtures are intentionally malformed; reformatting them would shift line numbers and break the sniff tests.
+    ->notPath('#^tests/Sniffs/#')
+    ->name('*.php');
+
+// mb_str_functions targets user-facing application strings. This package only processes ASCII PHP tokens,
+// so keep the plain byte-string functions and avoid pulling in an ext-mbstring runtime dependency.
+return Config::create(__DIR__, ruleOverrides: ['mb_str_functions' => false], finder: $finder);

--- a/IxDFCodingStandard/Helpers/ClassHelper.php
+++ b/IxDFCodingStandard/Helpers/ClassHelper.php
@@ -2,7 +2,7 @@
 
 namespace IxDFCodingStandard\Helpers;
 
-/** Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API */
-final class ClassHelper extends \SlevomatCodingStandard\Helpers\ClassHelper
-{
-}
+/**
+ * Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API
+ */
+final class ClassHelper extends \SlevomatCodingStandard\Helpers\ClassHelper {}

--- a/IxDFCodingStandard/Helpers/TokenHelper.php
+++ b/IxDFCodingStandard/Helpers/TokenHelper.php
@@ -2,7 +2,9 @@
 
 namespace IxDFCodingStandard\Helpers;
 
-/** Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API */
+/**
+ * Created based on \SlevomatCodingStandard\Helpers to have a SSoT for this internal API
+ */
 final class TokenHelper extends \SlevomatCodingStandard\Helpers\TokenHelper
 {
     public const array NAME_TOKEN_CODES = parent::NAME_TOKEN_CODES;

--- a/IxDFCodingStandard/Sniffs/Files/BemCasedFilenameSniff.php
+++ b/IxDFCodingStandard/Sniffs/Files/BemCasedFilenameSniff.php
@@ -5,7 +5,9 @@ namespace IxDFCodingStandard\Sniffs\Files;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-/** Checks that all file names are BEM-cased. */
+/**
+ * Checks that all file names are BEM-cased.
+ */
 final class BemCasedFilenameSniff implements Sniff
 {
     private const ERROR_TOO_MANY_DELIMITERS = 'TooManyElementModifiers';

--- a/IxDFCodingStandard/Sniffs/Functions/MissingOptionalArgumentSniff.php
+++ b/IxDFCodingStandard/Sniffs/Functions/MissingOptionalArgumentSniff.php
@@ -7,7 +7,9 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-/** Inspired by {@see \SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff}. */
+/**
+ * Inspired by {@see \SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff}.
+ */
 final class MissingOptionalArgumentSniff implements Sniff
 {
     public const CODE_MISSING_OPTIONAL_ARGUMENT = 'MissingOptionalArgument';
@@ -50,7 +52,7 @@ final class MissingOptionalArgumentSniff implements Sniff
 
         if ($isMethodCall) {
             $fqcn = $this->getClassNameOfMethodCall($phpcsFile, $stringPointer);
-            $fullyQualifiedFunctionName = "$fqcn::$functionName";
+            $fullyQualifiedFunctionName = "{$fqcn}::{$functionName}";
 
             if (! array_key_exists($fullyQualifiedFunctionName, $this->staticMethods)) {
                 return;

--- a/IxDFCodingStandard/Sniffs/Laravel/BladeTemplateExtractor.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/BladeTemplateExtractor.php
@@ -4,7 +4,7 @@ namespace IxDFCodingStandard\Sniffs\Laravel;
 
 use BadMethodCallException;
 
-/** phpcs:disable IxDFCodingStandard.Laravel.NonExistingBladeTemplate.TemplateNotFound */
+// phpcs:disable IxDFCodingStandard.Laravel.NonExistingBladeTemplate.TemplateNotFound -- directive, kept as a line comment so PHP-CS-Fixer does not turn it into a multi-line doc block
 final class BladeTemplateExtractor
 {
     private const INVALID_METHOD_CALL = 'Invalid method call';

--- a/IxDFCodingStandard/Sniffs/Laravel/DisallowGuardedAttributeSniff.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/DisallowGuardedAttributeSniff.php
@@ -24,7 +24,7 @@ final class DisallowGuardedAttributeSniff extends AbstractScopeSniff
     }
 
     /** @inheritDoc */
-    protected function processTokenWithinScope(File $phpcsFile, $varPointer, $currScope)
+    protected function processTokenWithinScope(File $phpcsFile, $varPointer, $currScope): void
     {
         $varToken = $phpcsFile->getTokens()[$varPointer];
 
@@ -57,7 +57,7 @@ final class DisallowGuardedAttributeSniff extends AbstractScopeSniff
     }
 
     /** @inheritDoc */
-    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr): void
     {
         // nothing to do here
     }

--- a/IxDFCodingStandard/Sniffs/Laravel/PhpViewExtractor.php
+++ b/IxDFCodingStandard/Sniffs/Laravel/PhpViewExtractor.php
@@ -15,10 +15,10 @@ final class PhpViewExtractor
             return false;
         }
 
-        return $tokens[$position - 1]['type'] === 'T_WHITESPACE' &&
-            $tokens[$position]['content'] === 'view' &&
-            $tokens[$position + 1]['content'] === '(' &&
-            $tokens[$position + 2]['type'] === 'T_CONSTANT_ENCAPSED_STRING';
+        return $tokens[$position - 1]['type'] === 'T_WHITESPACE'
+            && $tokens[$position]['content'] === 'view'
+            && $tokens[$position + 1]['content'] === '('
+            && $tokens[$position + 2]['type'] === 'T_CONSTANT_ENCAPSED_STRING';
     }
 
     /** @param array<array<string>> $tokens */

--- a/IxDFCodingStandard/TokenHelper.php
+++ b/IxDFCodingStandard/TokenHelper.php
@@ -2,7 +2,7 @@
 
 namespace IxDFCodingStandard;
 
-/** Just a wrapper for the parent class that is marked as internal */
-final class TokenHelper extends \SlevomatCodingStandard\Helpers\TokenHelper
-{
-}
+/**
+ * Just a wrapper for the parent class that is marked as internal
+ */
+final class TokenHelper extends \SlevomatCodingStandard\Helpers\TokenHelper {}

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
         "cs": "@cs:fix",
         "cs:check": "phpcs -p -s --colors --report-full --report-summary --cache=.cache/phpcs",
         "cs:fix": "phpcbf -p --colors --cache=.cache/phpcs",
+        "php-cs-fixer": "php-cs-fixer fix --no-interaction --ansi",
+        "php-cs-fixer:check": "php-cs-fixer fix --dry-run --diff --no-interaction --ansi",
         "sa": "@psalm",
         "psalm": "psalm --config=psalm.xml",
         "psalm:bl": "@psalm --set-baseline=psalm-baseline.xml --long-progress --no-cache",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,4 @@
 
 namespace IxDFCodingStandard;
 
-abstract class TestCase extends \SlevomatCodingStandard\Sniffs\TestCase
-{
-}
+abstract class TestCase extends \SlevomatCodingStandard\Sniffs\TestCase {}


### PR DESCRIPTION
## Summary

Follow-up to the PHP-CS-Fixer config work. The package never linted itself with its own shared config, so config regressions could ship unnoticed (that is how the `@api`-strip and the arrow/octal/numeric-separator surprises slipped through earlier). This adds a self-lint plus a strict CI gate.

## Changes

- **`.php-cs-fixer.dist.php`** — lints this package with `Config::create()`. Excludes `vendor`/`.cache` and the intentionally-malformed sniff test fixtures (`tests/Sniffs/**`, reformatting them would shift line numbers and break the sniff tests). Disables `mb_str_functions`: this package processes ASCII PHP tokens, not user-facing strings, so it should not pull in an `ext-mbstring` runtime dependency.
- **`composer.json`** — `php-cs-fixer` (fix) and `php-cs-fixer:check` (dry-run) scripts.
- **`.github/workflows/php-cs-fixer.yml`** — strict dry-run gate (mirrors `psalm.yml`). Intentionally a hard gate, not the auto-commit pattern of `format_php.yml`, so a rule renamed/removed by a Renovate bump fails loudly.
- Applied the resulting formatting to the package source.
- **`BladeTemplateExtractor`** — the `phpcs:disable` was a `/** */` doc block; PHP-CS-Fixer expanded it to multi-line, which then tripped `SlevomatCodingStandard.Commenting.RequireOneLineDocComment`. Changed it to a line comment (a directive is not documentation). This conflict was found by the new self-lint.

## Verification

- `composer php-cs-fixer:check` exits 0 (idempotent).
- `vendor/bin/phpunit`: 18 passing (fixtures untouched).
- `phpcs` self-check: 0 errors.
- `composer validate`: clean.